### PR TITLE
Strip . wildcard from logged_in_cookie domain

### DIFF
--- a/src/gto-cas-login.php
+++ b/src/gto-cas-login.php
@@ -550,9 +550,9 @@ namespace {
     }
 
     if ( false === $logged_in ) {
-      setcookie( 'logged_in_cookie', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+      setcookie( 'logged_in_cookie', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, ltrim(COOKIE_DOMAIN, '.') );
     } else {
-      setcookie( 'logged_in_cookie', 'logged_in', time() + 2 * HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, true, true );
+      setcookie( 'logged_in_cookie', 'logged_in', time() + 2 * HOUR_IN_SECONDS, COOKIEPATH, ltrim(COOKIE_DOMAIN, '.'), true, true );
     }
 
     return $logged_in;


### PR DESCRIPTION
This was creating cookies for `.www.familylife.com` and `.sites-stage.familylife.com` which Chrome is saying are both valid for `www-stage.familylife.com`.

This will strip the wildcard `.` to make `logged_in_cookie` more strict.