### PR TITLE
Implements 'require login' functionality for pages.

### DIFF
--- a/src/js/require-login.js
+++ b/src/js/require-login.js
@@ -1,0 +1,50 @@
+(function (wp) {
+    var registerPlugin = wp.plugins.registerPlugin;
+    var PluginPostStatusInfo = wp.editPost.PluginPostStatusInfo;
+    var el = wp.element.createElement;
+    var CheckboxControl = wp.components.CheckboxControl;
+    var withSelect = wp.data.withSelect;
+    var withDispatch = wp.data.withDispatch;
+    var compose = wp.compose.compose;
+
+    var mapSelectToProps = function (select) {
+        return {
+            requiresLogin: select('core/editor').getEditedPostAttribute('meta')['gtocas_requires_login']
+        }
+    };
+
+    var mapDispatchToProps = function (dispatch) {
+        return {
+            setRequiresLogin: function (value) {
+                dispatch('core/editor').editPost(
+                    {meta: {gtocas_requires_login: value}}
+                );
+            }
+        }
+    };
+
+    var RequiresLoginCheckbox = compose(
+        withSelect(mapSelectToProps),
+        withDispatch(mapDispatchToProps)
+    )(function (props) {
+        return (
+            el(CheckboxControl, {
+                label: 'Requires Login',
+                checked: props.requiresLogin,
+                onChange: function (value) {
+                    props.setRequiresLogin(value)
+                }
+            })
+        )
+    });
+
+    function RequiresLogin() {
+        return (
+            el(PluginPostStatusInfo, {}, el(RequiresLoginCheckbox))
+        )
+    }
+
+    registerPlugin('gtocas-requires-login', {
+        render: RequiresLogin
+    });
+})(window.wp);


### PR DESCRIPTION
A couple users of Cru WordPress have been interested in this functionality. We couldn't find any plugins that provided it out of the box.

This adds and option to pages called "Requires Login" that when selected will require that the current user is "logged in" (`auth_redirect()`) to view the pages. This implements the functionality in both the Blocks editor and the classic editor.

This doesn't implement any sort of role checking. Since this is a Network, it means someone who isn't a member of the site, but is logged into WordPress can see the page (Not all users of WordPress are users of each site). Use one of the existing plugins to enforce roles.